### PR TITLE
トランザクション分離レベルのTODOコメントを削除

### DIFF
--- a/internal/infrastructure/database/tx.go
+++ b/internal/infrastructure/database/tx.go
@@ -8,7 +8,7 @@ import (
 )
 
 func WithTransaction(ctx context.Context, db *sql.DB, fn func(q *Queries) error) error {
-	tx, err := db.BeginTx(ctx, nil) // TODO: トランザクション分離レベルをどうするか検討する
+	tx, err := db.BeginTx(ctx, nil)
 	if err != nil {
 		return errors.WithStack(errors.NewInternalError(err))
 	}


### PR DESCRIPTION
MySQLではデフォルトでREPEATABLE READ && ファントムリードが発生しないのでデフォルトで問題ないと判断したため
see: https://qiita.com/song_ss/items/38e514b05e9dabae3bdb#repeatable-read