### PR TITLE
internal server error発生時にログにエラー内容を表示するように修正

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -69,7 +69,7 @@ func loggerInterceptor(logger *slog.Logger) grpc.UnaryServerInterceptor {
 
 		resp, err := handler(ctx, req)
 		if err != nil {
-			logger.Error("error", "method", methodName, "error", errors.GetStackTrace(err))
+			logger.Error(err.Error(), "method", methodName, "error", errors.GetStackTrace(err))
 			if !errors.IsPrecondition(err) {
 				return resp, status.Error(codes.Internal, "internal server error")
 			}


### PR DESCRIPTION
internal server error発生時にログにエラー内容を表示するように修正した。(これまでは誤ってerrorという固定値を出力してしまっていた)