### PR TITLE
refactor: User構造体のフィールドをprivateに変更

### DIFF
--- a/internal/apperrors/errors.go
+++ b/internal/apperrors/errors.go
@@ -7,6 +7,7 @@ import (
 	goerrors "github.com/go-errors/errors"
 )
 
+// TODO: add UT
 type (
 	ErrorType    int
 	TwitterError struct {

--- a/internal/domain/user/service.go
+++ b/internal/domain/user/service.go
@@ -21,7 +21,7 @@ func NewUserService(userRepository UserRepository) *UserService {
 
 // TODO: add UT
 func (s UserService) CreateUser(ctx context.Context, rwtx *spanner.ReadWriteTransaction, user *User) error {
-	isExisting, err := s.IsExistingScreenName(ctx, rwtx, user.ScreenName)
+	isExisting, err := s.IsExistingScreenName(ctx, rwtx, user.screenName)
 	if err != nil {
 		return apperrors.WithStack(err)
 	}

--- a/internal/domain/user/user.go
+++ b/internal/domain/user/user.go
@@ -6,12 +6,15 @@ import (
 	"github.com/kyu08/go-api-server-playground/internal/domain"
 )
 
-// TODO: ID以外全部privateにする
+// User はユーザーを表すエンティティ。
+// 基本的にフィールドはprivateにしてドメインロジックの流出を防ぐ。
+// IDやCreatedAtなどの更新されないフィールドに関してはpublicにしている。
+// これらのフィールドは基本的に変更されないのでpublicにするデメリット(安全性の低下)が少ないと判断したため。
 type User struct {
 	ID         domain.ID[User]
-	ScreenName ScreenName
-	UserName   UserName
-	Bio        Bio
+	screenName ScreenName
+	userName   UserName
+	bio        Bio
 	CreatedAt  time.Time
 }
 
@@ -49,9 +52,9 @@ func newUser(id domain.ID[User], screenName, userName, bio string, createdAt tim
 
 	user := &User{
 		ID:         id,
-		ScreenName: s,
-		UserName:   u,
-		Bio:        b,
+		screenName: s,
+		userName:   u,
+		bio:        b,
 		CreatedAt:  createdAt,
 	}
 	if err := user.validate(); err != nil {
@@ -59,6 +62,18 @@ func newUser(id domain.ID[User], screenName, userName, bio string, createdAt tim
 	}
 
 	return user, nil
+}
+
+func (u *User) ScreenName() ScreenName {
+	return u.screenName
+}
+
+func (u *User) UserName() UserName {
+	return u.userName
+}
+
+func (u *User) Bio() Bio {
+	return u.bio
 }
 
 func (u *User) validate() error {

--- a/internal/domain/user/user_test.go
+++ b/internal/domain/user/user_test.go
@@ -34,9 +34,9 @@ func TestNewUser(t *testing.T) {
 			},
 			want: &User{
 				ID:         domain.NewID[User](),
-				ScreenName: "screen_name",
-				UserName:   "user_name",
-				Bio:        "bio",
+				screenName: "screen_name",
+				userName:   "user_name",
+				bio:        "bio",
 				CreatedAt:  time.Time{},
 			},
 			wantErrMsg: nil,
@@ -82,7 +82,11 @@ func TestNewUser(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			if diff := cmp.Diff(tt.want, got, cmpopts.IgnoreFields(User{}, "ID", "CreatedAt")); diff != "" {
+			opts := []cmp.Option{
+				cmpopts.IgnoreFields(User{}, "ID", "CreatedAt"),
+				cmp.AllowUnexported(User{}),
+			}
+			if diff := cmp.Diff(tt.want, got, opts...); diff != "" {
 				t.Errorf("New() mismatch (-want +got) = \n%s", diff)
 			}
 		})
@@ -115,9 +119,9 @@ func TestNewFromDTO(t *testing.T) {
 			},
 			want: &User{
 				ID:         lo.Must(domain.NewFromString[User]("f541dd5f-48fd-40d6-8e5b-6c25b4681f3c")),
-				ScreenName: "screen_name",
-				UserName:   "user_name",
-				Bio:        "bio",
+				screenName: "screen_name",
+				userName:   "user_name",
+				bio:        "bio",
 				CreatedAt:  time.Date(2025, time.December, 30, 0, 0, 0, 0, time.UTC),
 			},
 			wantErr: nil,
@@ -174,7 +178,12 @@ func TestNewFromDTO(t *testing.T) {
 				require.EqualError(t, err, tt.wantErr.Error())
 			} else {
 				require.NoError(t, err)
-				if diff := cmp.Diff(tt.want, got, cmpopts.IgnoreFields(User{}, "ID", "CreatedAt")); diff != "" {
+
+				opts := []cmp.Option{
+					cmpopts.IgnoreFields(User{}, "ID", "CreatedAt"),
+					cmp.AllowUnexported(User{}),
+				}
+				if diff := cmp.Diff(tt.want, got, opts...); diff != "" {
 					t.Errorf("NewFromDTO() mismatch (-want +got) = \n%s", diff)
 				}
 			}

--- a/internal/infrastructure/database/repository/user.go
+++ b/internal/infrastructure/database/repository/user.go
@@ -56,9 +56,9 @@ func (UserRepository) apply(rwtx domain.ReadWriteDB, m []*spanner.Mutation) erro
 func (UserRepository) fromDomain(u *user.User) *User {
 	return &User{
 		ID:         u.ID.String(),
-		ScreenName: u.ScreenName.String(),
-		UserName:   u.UserName.String(),
-		Bio:        u.Bio.String(),
+		ScreenName: u.ScreenName().String(),
+		UserName:   u.UserName().String(),
+		Bio:        u.Bio().String(),
 		CreatedAt:  u.CreatedAt,
 	}
 }

--- a/internal/usecase/find_user_by_screen_name.go
+++ b/internal/usecase/find_user_by_screen_name.go
@@ -59,9 +59,9 @@ func (u FindUserByScreenNameUsecase) Run(
 
 	return &FindUserByScreenNameOutput{
 		ID:         foundUser.ID,
-		ScreenName: foundUser.ScreenName,
-		UserName:   foundUser.UserName,
-		Bio:        foundUser.Bio,
+		ScreenName: foundUser.ScreenName(),
+		UserName:   foundUser.UserName(),
+		Bio:        foundUser.Bio(),
 	}, nil
 }
 


### PR DESCRIPTION
## WHAT
SSIA

## WHY
- ドメイン知識の流出を防ぐために主要な（変更される可能性のある）フィールドをprivateに変更。
- get, setter定義の手間はあるが、カプセル化できることによる品質向上（影響範囲の局所化）の方が価値があると判断した。
- （というのはありつつ、もしかしたら静的解析でpackage外でのsetを禁止すれば仕組みでドメイン貧血を防ぎつつGetterを定義するコストをなくせるかもしれない。）