### PR TITLE
refactor: graceful shutdownにタイムアウトを追加し、エラーハンドリングを統一

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,4 +56,5 @@ format-buf:
 
 ci: gen-all lint-go test-gotestsum
 
+# hoge
 .PHONY: dev-tools gen-proto gen-yo gen-all run test lint-go build handler-list health-check ci format-buf

--- a/README.md
+++ b/README.md
@@ -24,3 +24,4 @@
 ## ローカルでの開発手順
 1. `make dev-tools`で必要なツールをインストール
 1. 必要に応じて`make test`, `make lint`などを実行
+## Hello

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"os"
 	"os/signal"
+	"time"
 
 	"github.com/apstndb/spanemuboost"
 	grpc_recovery "github.com/grpc-ecosystem/go-grpc-middleware/recovery"
@@ -24,14 +25,13 @@ func main() {
 	// そのためエミュレーターに接続する前提で実装している。
 	emulator, emulatorTeardown, err := spanemuboost.NewEmulator(context.Background(), spanemuboost.EnableInstanceAutoConfigOnly())
 	if err != nil {
-		log.Fatalln(err)
-		return
+		log.Fatalf("failed to create emulator: %v", err)
 	}
 	defer emulatorTeardown()
 
 	client, teardown, err := database.GetSpannerClient(emulator)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to get spanner client: %v", err)
 	}
 	defer teardown()
 
@@ -59,11 +59,11 @@ func main() {
 
 		listener, err := net.Listen("tcp", fmt.Sprintf("%s:%d", host, port))
 		if err != nil {
-			panic(err)
+			log.Fatalf("failed to listen on port %d: %v", port, err)
 		}
 
 		if err := server.Serve(listener); err != nil {
-			panic(err)
+			log.Fatalf("failed to serve gRPC server: %v", err)
 		}
 	}()
 
@@ -71,5 +71,21 @@ func main() {
 	signal.Notify(quit, os.Interrupt)
 	<-quit
 	logger.Info("stopping gRPC server...")
-	server.GracefulStop() // NOTE: 受け付けているリクエストを捌き切ってからサーバーを停止するために必要
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	stopped := make(chan struct{})
+	go func() {
+		server.GracefulStop()
+		close(stopped)
+	}()
+
+	select {
+	case <-stopped:
+		logger.Info("gRPC server stopped gracefully")
+	case <-ctx.Done():
+		logger.Warn("graceful stop timed out, forcing shutdown")
+		server.Stop()
+	}
 }

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -31,6 +31,7 @@ func main() {
 
 	client, teardown, err := database.GetSpannerClient(emulator)
 	if err != nil {
+		emulatorTeardown()
 		log.Fatalf("failed to get spanner client: %v", err)
 	}
 	defer teardown()
@@ -72,7 +73,13 @@ func main() {
 	<-quit
 	logger.Info("stopping gRPC server...")
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	gracefulShutdown(logger, server)
+}
+
+const gracefulStopTimeout = 10 * time.Second
+
+func gracefulShutdown(logger *slog.Logger, server *grpc.Server) {
+	ctx, cancel := context.WithTimeout(context.Background(), gracefulStopTimeout)
 	defer cancel()
 
 	stopped := make(chan struct{})

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -31,8 +31,8 @@ func main() {
 
 	client, teardown, err := database.GetSpannerClient(emulator)
 	if err != nil {
-		emulatorTeardown()
-		log.Fatalf("failed to get spanner client: %v", err)
+		log.Printf("failed to get spanner client: %v", err)
+		return
 	}
 	defer teardown()
 

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/kyu08/go-api-server-playground
 
 go 1.25.4
 
+// TODO: foo
+
 require (
 	cloud.google.com/go/spanner v1.73.0
 	github.com/apstndb/spanemuboost v0.2.16


### PR DESCRIPTION
## WHAT
- `server.GracefulStop()` にタイムアウト(10秒)を追加し、タイムアウト時は `server.Stop()` にフォールバックするように変更
- `panic` / `log.Fatalln` が混在していたエラーハンドリングを `log.Fatalf` に統一
- `log.Fatalln` 後の到達不能な `return` 文を削除

## WHY
- `GracefulStop()` はタイムアウトがないため、長時間リクエストがあるとサーバーが永久に停止できなくなる
- エラー時の処理が `panic` / `log.Fatalln` / `log.Fatalln` + 到達不能な `return` とバラバラで一貫性がなかった

NOTE: This is a demo PR for fude.nvim.